### PR TITLE
collect backup info using tail

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,7 @@ NVIDIA Graphics ISO:
 
 Before upgrading an existing Pop!\_OS installation, run these commands to collect information about your system's installed sources and packages:
 ```
-cat /etc/apt/sources.list >> sources.txt
-ls -alh /etc/apt/sources.list.d/ >> sources.txt
-cat /etc/apt/sources.list.d/* >> sources.txt
+tail -n +1 /etc/apt/sources.list /etc/apt/sources.list.d/* > sources.txt
 apt list --installed > packages.txt
 ```
 Save these files in case they're needed to recreate any issues encountered while upgrading.


### PR DESCRIPTION
Condensing 3 commands to output backup information into a single command using tail which includes file names as section headers in the text file like this:
```
$ cat sources.txt
==> /etc/apt/sources.list <==
## This file is deprecated in Pop!_OS.
## See `man deb822` and /etc/apt/sources.list.d/system.sources.

==> /etc/apt/sources.list.d/brave-browser-release.list <==
# deb [signed-by=/usr/share/keyrings/brave-browser-archive-keyring.gpg arch=amd64] https://brave-browser-apt-release.s3.brave.com/ stable main

==> /etc/apt/sources.list.d/brave-browser-release.list.save <==
deb [signed-by=/usr/share/keyrings/brave-browser-archive-keyring.gpg arch=amd64] https://brave-browser-apt-release.s3.brave.com/ stable main
...
```